### PR TITLE
use StateReply::Symbol for State::Symbol

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn meta_state() -> *mut [i32; 2] {
     debug!("{:?}", query);
     let encoded = match query {
         State::Name => StateReply::Name(ft.name.clone()),
-        State::Symbol => StateReply::Name(ft.symbol.clone()),
+        State::Symbol => StateReply::Symbol(ft.symbol.clone()),
         State::Decimals => StateReply::Decimals(ft.decimals),
         State::TotalSupply => StateReply::TotalSupply(ft.total_supply),
         State::BalanceOf(account) => {


### PR DESCRIPTION
Currently requesting symbol returns `name: <symbol>` when it is expected to receive `symbol: <symbol>`. 
This is because incorrect  `StateReply::Name` (should be `StateReply::Symbol`) for `State::Symbol` is used. This PR fixes the issue.